### PR TITLE
fix(utils): fix identfication parse in log_to_json util

### DIFF
--- a/src/utils/log_to_json.py
+++ b/src/utils/log_to_json.py
@@ -9,7 +9,7 @@ Lines = fd.readlines()
 
 for line in Lines:
 
-    identification = re.compile(r'(^\d.*])').findall(line)[0]
+    identification = re.compile(r'(^\d.*]) \"').findall(line)[0]
     body = re.compile(r'(\".*)').findall(line)[0]
 
     ip = re.match(r'([0-9]+\.){3}[0-9]+', identification).group()


### PR DESCRIPTION
The `log_to_json.py` util was incorrectly parsing the identification field due to a repetition of the `[` character in the referrer URL.