### PR TITLE
feat(log-processing): update processing interfaces

### DIFF
--- a/src/filter/filter_interface.py
+++ b/src/filter/filter_interface.py
@@ -9,7 +9,3 @@ class IFilter(ABC):
     @abstractmethod
     def filter(self, log: Log) -> bool:
         pass
-
-    @abstractmethod
-    def get_parameters(self) -> Dict[str, Any]:
-        pass

--- a/src/forwarder/forwarder_interface.py
+++ b/src/forwarder/forwarder_interface.py
@@ -11,7 +11,3 @@ class IForwarder(ABC):
     @abstractmethod
     def forward(self, log: Log) -> int:
         pass
-
-    @abstractmethod
-    def forwardMany(self, logs: List[Log]) -> int:
-        pass

--- a/src/transformer/transformer_interface.py
+++ b/src/transformer/transformer_interface.py
@@ -3,7 +3,4 @@ from src.log import Log
 from abc import ABC, abstractmethod
 
 class ITransformer(ABC):
-
-    @abstractmethod
-    def transform(self, log: Log) -> Log:
-        pass
+    pass


### PR DESCRIPTION
* `Transformer` interface should not force any method.
* `get_paremeters` from `Filter` interface won't be used.
* `forwardmany` from `Forwarder` interface won't be used.