### PR TITLE
feat(log-processing): remove bitstream acces resource use case

### DIFF
--- a/src/logs/filter/access_resource.py
+++ b/src/logs/filter/access_resource.py
@@ -1,6 +1,6 @@
 from src.logs.filter.filter_interface import IFilter
 
-from src.logs.utils.regex_patterns import BITSTREAM, HANDLE
+from src.logs.utils.regex_patterns import HANDLE
 
 import re
 
@@ -9,4 +9,4 @@ class AccessResource(IFilter):
 
     @classmethod
     def filter(cls, resource: str) -> bool:
-        return bool(re.search(HANDLE, resource)) or bool(re.search(BITSTREAM, resource))
+        return bool(re.search(HANDLE, resource))

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -19,6 +19,7 @@ class InfluxDbForwarder(IForwarder):
     @classmethod
     def forward(cls, log: dict, raw_log: str) -> int:
 
+        # TODO: check dict when content == 'error'
         data = [{
             'measurement': 'demo',
             'tags': cls._set_log_tags(log),

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -55,3 +55,10 @@ def process_log(line: str):
         AddLabel.transform(log, LABEL_TYPE, LABEL_TYPE_OTHERS)
 
     return InfluxDbForwarder.forward(log, line)
+
+
+# with open('13-03-2015.log', mode='rb') as file:
+#     logs = file.readlines()
+#
+#     for log in logs:
+#         process_log(log.decode('utf-8', errors='ignore'))

--- a/src/logs/transformer/add_resource_id_label.py
+++ b/src/logs/transformer/add_resource_id_label.py
@@ -1,6 +1,6 @@
 from src.logs.transformer.transformer_interface import ITransformer
 
-from src.logs.utils.regex_patterns import BITSTREAM, HANDLE
+from src.logs.utils.regex_patterns import HANDLE
 
 import re
 
@@ -16,12 +16,4 @@ class AddResourceIdLabel(ITransformer):
             ids = list({id[0] for id in handle})
             ids = ids[0] if len(ids) == 1 else ids
 
-        else:
-
-            bitstream = re.compile(BITSTREAM).findall(resource)
-            if len(bitstream) > 0:
-
-                ids = list({id for id in bitstream})
-                ids = ids[0] if len(ids) == 1 else ids
-
-        log['resource'] = ids
+            log['resource'] = ids

--- a/src/logs/utils/regex_patterns.py
+++ b/src/logs/utils/regex_patterns.py
@@ -1,7 +1,6 @@
 IPV6_PATTERN = r"^([a-fA-F0-9:]+|[uU]nknown), "
 WEB_EXTENSIONS = r'.*\.(js|woff|jpg|css|png(.*)?|ico|txt|gif)$'
 HANDLE = r'((2099(.[1-4])?|2117)\/\d+)'
-BITSTREAM = r'bitstream\/id\/([^\/]*)\/'
 SEARCH_KEYS = [
     'discover?', 'scholar?', 'examens?',
     'browse?', 'browse-', '-search?', 'search?', 'search-filter?',


### PR DESCRIPTION
- We are not longer processing the logs that contains a file access via bitstream UUID as an access resource, so we are removing it from the log processing workflow