### PR TITLE
feat(InfluxDbForwarder): add batching to InfluxDb write

### DIFF
--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -34,6 +34,11 @@ class InfluxDbForwarder(IForwarder):
         # TODO: return correct value
         return 0
 
+    @classmethod
+    def close(cls) -> None:
+        if cls.influxDbClient is not None:
+            cls.influxDbClient.close()
+
     @staticmethod
     def _set_log_tags(log: dict) -> dict:
         if log['content'] == "error":

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -3,7 +3,7 @@ from src.logs.forwarder.forwarder_interface import IForwarder
 from src.logs.utils.date_converter import to_timestamp
 
 from influxdb_client import InfluxDBClient
-from influxdb_client.client.write_api import ASYNCHRONOUS
+from influxdb_client.client.write_api import SYNCHRONOUS
 
 import os
 
@@ -70,7 +70,7 @@ class InfluxDbForwarder(IForwarder):
                 url=cls.influxdb_url,
                 token=cls.influxdb_token,
                 enable_gzip=True
-            ).write_api(ASYNCHRONOUS)
+            ).write_api(SYNCHRONOUS)
         return cls.influxDbClient
 
     @classmethod

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -66,7 +66,11 @@ class InfluxDbForwarder(IForwarder):
         # TODO: check race condition
         if cls.influxDbClient is None:
             cls._get_influxdb_credentials()
-            cls.influxDbClient = InfluxDBClient(url=cls.influxdb_url, token=cls.influxdb_token).write_api(ASYNCHRONOUS)
+            cls.influxDbClient = InfluxDBClient(
+                url=cls.influxdb_url,
+                token=cls.influxdb_token,
+                enable_gzip=True
+            ).write_api(ASYNCHRONOUS)
         return cls.influxDbClient
 
     @classmethod

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -3,7 +3,6 @@ from src.logs.forwarder.forwarder_interface import IForwarder
 from src.logs.utils.date_converter import to_timestamp
 
 from influxdb_client import InfluxDBClient
-from influxdb_client.client.write_api import SYNCHRONOUS
 
 import os
 
@@ -69,7 +68,7 @@ class InfluxDbForwarder(IForwarder):
                 url=cls.influxdb_url,
                 token=cls.influxdb_token,
                 enable_gzip=True
-            ).write_api(SYNCHRONOUS)
+            ).write_api()
         return cls.influxDbClient
 
     @classmethod

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -23,7 +23,7 @@ class InfluxDbForwarder(IForwarder):
     def forward(cls, log: dict, raw_log: str) -> int:
 
         data = {
-            'measurement': 'demo',
+            'measurement': 'tfg',
             'tags': cls._set_log_tags(log),
             'fields': cls._set_log_fields(log, raw_log),
             'time': cls._set_timestamp(log['date'], log['time'])
@@ -31,7 +31,7 @@ class InfluxDbForwarder(IForwarder):
 
         client_write_api = cls._get_influxdb_client_write()
 
-        client_write_api.write(record=data, write_precision='s', org=cls.influxdb_org, bucket=cls.influxdb_bucket)
+        client_write_api.write(record=data, write_precision='ns', org=cls.influxdb_org, bucket=cls.influxdb_bucket)
 
         # TODO: return correct value
         return 0

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -63,7 +63,6 @@ class InfluxDbForwarder(IForwarder):
 
     @classmethod
     def _get_influxdb_client_write(cls) -> InfluxDBClient:
-        # TODO: check race condition
         if cls.influxDbClient is None:
             cls._get_influxdb_credentials()
             cls.influxDbClient = InfluxDBClient(

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -40,10 +40,10 @@ class InfluxDbForwarder(IForwarder):
             return {'content': "error"}
         else:
             return {
-                'type': log['type'],
                 'content': log['content'],
                 'method': log['request']['method'],
-                'status_code': log['request']['status_code']
+                'status_code': log['request']['status_code'],
+                'type': log['type']
             }
 
     @staticmethod

--- a/src/logs/forwarder/influxdb_forwarder.py
+++ b/src/logs/forwarder/influxdb_forwarder.py
@@ -3,6 +3,7 @@ from src.logs.forwarder.forwarder_interface import IForwarder
 from src.logs.utils.date_converter import to_timestamp
 
 from influxdb_client import InfluxDBClient
+from influxdb_client.client.write_api import WriteOptions, WriteType
 
 import os
 
@@ -68,7 +69,12 @@ class InfluxDbForwarder(IForwarder):
                 url=cls.influxdb_url,
                 token=cls.influxdb_token,
                 enable_gzip=True
-            ).write_api()
+            ).write_api(
+                write_options=WriteOptions(
+                    write_type=WriteType.batching,
+                    batch_size=500,
+                    flush_interval=2_000
+            ))
         return cls.influxDbClient
 
     @classmethod

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -67,3 +67,5 @@ def process_log(line: str):
 #
 #     for log in logs:
 #         process_log(log.decode('utf-8', errors='ignore'))
+#
+#     InfluxDbForwarder.close()

--- a/src/logs/utils/date_converter.py
+++ b/src/logs/utils/date_converter.py
@@ -12,3 +12,8 @@ def to_iso_format(date: str, time: str) -> tuple[str, str]:
 def to_timestamp(date: str, time: str) -> int:
 
     return int(datetime.strptime(date + ' ' + time, '%d/%b/%Y %H:%M:%S %z').timestamp())
+
+
+def to_nanoseconds(date: str, time: str) -> int:
+
+    return int(to_timestamp(date, time) * 1e9)


### PR DESCRIPTION
- to increase write performance
  - reorder tag fields
  - use `nanoseconds` write precision
  - write in `batching` mode
    - flush at least `every 2 seconds`
    - `500 items` batch size
- add `close` client function, InfluxDb must run as a singleton  
