### PR TITLE
feat(log-processing): add stats to main process_log function

### DIFF
--- a/config/docker-compose.yaml
+++ b/config/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     networks:
       - monitoring
   mongo:
-    image: mongo:latest
+    image: mongo:4.4.6
     restart: always
     env_file:
       - ./mongo/mongo.env

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -8,7 +8,7 @@ from src.logs.filter.access_resource_bitstream import AccessResourceBitstream
 
 from src.logs.transformer.to_json import ToJSON
 from src.logs.transformer.add_label import AddLabel
-from src.logs.transformer.add_timestamp import AddTimestamp
+from src.logs.transformer.add_timestamp import AddTimestampForwarder
 from src.logs.transformer.remove_ipv6address import RemoveIPv6Address
 from src.logs.transformer.add_resource_id_label import AddResourceIdLabel
 from src.logs.transformer.add_default_ipaddress import AddDefaultIpAddress
@@ -46,7 +46,7 @@ def process_log(line: str) -> dict:
             LABEL_VALUE: line,
             LABEL_CONTENT: LABEL_CONTENT_ERROR
         }
-        AddTimestamp.transform(log, line)
+        AddTimestampForwarder.transform(log, line)
         InfluxDbForwarder.forward(log, line)
 
         stats[LABEL_CONTENT] = LABEL_CONTENT_ERROR
@@ -80,7 +80,7 @@ def process_log(line: str) -> dict:
     return stats
 
 
-year = XXXX
+year = 0
 totalLogs = 0
 input_path = os.environ.get('LOGS_OUTPUT_PATH')
 

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -45,7 +45,7 @@ def process_log(line: str) -> dict:
             LABEL_VALUE: line,
             LABEL_CONTENT: LABEL_CONTENT_ERROR
         }
-        # InfluxDbForwarder.forward(log, line)
+        InfluxDbForwarder.forward(log, line)
 
         stats[LABEL_CONTENT] = LABEL_CONTENT_ERROR
         return stats
@@ -73,7 +73,7 @@ def process_log(line: str) -> dict:
         AddLabel.transform(log, LABEL_TYPE, LABEL_TYPE_OTHERS)
         stats[LABEL_TYPE] = LABEL_TYPE_OTHERS
 
-    # InfluxDbForwarder.forward(log, line)
+    InfluxDbForwarder.forward(log, line)
 
     return stats
 

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -95,7 +95,7 @@ global_stats = {
 }
 
 start_time = time.time()
-for month in range(1, 12):
+for month in range(1, 13):
 
     folder = Path(input_path) / Path(str(year)) / Path(f'{month:02}')
 

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -15,13 +15,19 @@ from src.logs.transformer.add_default_ipaddress import AddDefaultIpAddress
 from src.logs.forwarder.influxdb_forwarder import InfluxDbForwarder
 
 from src.logs.utils.constants import LABEL_VALUE
-from src.logs.utils.constants import LABEL_TYPE, LABEL_TYPE_OTHERS, LABEL_TYPE_SEARCH, LABEL_TYPE_RESOURCE
+from src.logs.utils.constants import LABEL_TYPE, LABEL_TYPE_OTHERS, LABEL_TYPE_SEARCH, LABEL_TYPE_RESOURCE, LABEL_TYPE_RESOURCE_WEB
 from src.logs.utils.constants import LABEL_CONTENT, LABEL_CONTENT_OK, LABEL_CONTENT_ERROR, LABEL_CONTENT_DIFFERENT
 
+import os
+import json
+import time
+from pathlib import Path
 
-def process_log(line: str):
+
+def process_log(line: str) -> dict:
 
     log = {}
+    stats = {}
 
     if WithoutIpAddress.filter(line):
         line = AddDefaultIpAddress.transform(line)
@@ -39,33 +45,82 @@ def process_log(line: str):
             LABEL_VALUE: line,
             LABEL_CONTENT: LABEL_CONTENT_ERROR
         }
-        return InfluxDbForwarder.forward(log, line)
+        # InfluxDbForwarder.forward(log, line)
+
+        stats[LABEL_CONTENT] = LABEL_CONTENT_ERROR
+        return stats
 
     AddLabel.transform(log, LABEL_CONTENT, LABEL_CONTENT_OK if status == 0 else LABEL_CONTENT_DIFFERENT)
 
     if AccessResource.filter(resource):
         AddResourceIdLabel.transform(log, resource)
         AddLabel.transform(log, LABEL_TYPE, LABEL_TYPE_RESOURCE)
+        stats[LABEL_TYPE] = LABEL_TYPE_RESOURCE
 
     elif AccessResourceBitstream.filter(resource):
         AddLabel.transform(log, LABEL_TYPE, LABEL_TYPE_RESOURCE)
+        stats[LABEL_TYPE] = LABEL_TYPE_RESOURCE
 
     elif WebResource.filter(resource):
-        return
+        stats[LABEL_TYPE] = LABEL_TYPE_RESOURCE_WEB
+        return stats
 
     elif SearchResource.filter(resource):
         AddLabel.transform(log, LABEL_TYPE, LABEL_TYPE_SEARCH)
+        stats[LABEL_TYPE] = LABEL_TYPE_SEARCH
 
     else:
         AddLabel.transform(log, LABEL_TYPE, LABEL_TYPE_OTHERS)
+        stats[LABEL_TYPE] = LABEL_TYPE_OTHERS
 
-    return InfluxDbForwarder.forward(log, line)
+    # InfluxDbForwarder.forward(log, line)
+
+    return stats
 
 
-# with open('13-03-2015.log', mode='rb') as file:
-#     logs = file.readlines()
-#
-#     for log in logs:
-#         process_log(log.decode('utf-8', errors='ignore'))
-#
-#     InfluxDbForwarder.close()
+year = 2006
+totalLogs = 0
+input_path = os.environ.get('LOGS_OUTPUT_PATH')
+
+global_stats = {
+    'total_logs': 0,
+    LABEL_TYPE_RESOURCE: 0,
+    LABEL_TYPE_SEARCH: 0,
+    LABEL_TYPE_RESOURCE_WEB: 0,
+    LABEL_TYPE_OTHERS: 0,
+    LABEL_CONTENT_ERROR: 0,
+    'time': 0.0
+}
+
+start_time = time.time()
+for month in range(1, 12):
+
+    folder = Path(input_path) / Path(str(year)) / Path(f'{month:02}')
+
+    for day in range(1, 32):
+
+        log_file = folder / Path(f'{year}-{month:02}-{day:02}.log')
+
+        if log_file.exists():
+
+            print(f'{year}-{month:02}-{day:02}.log ...')
+
+            with open(log_file, mode='rb') as file:
+                logs = file.readlines()
+                totalLogs = totalLogs + len(logs)
+
+                for log in logs:
+                    stats = process_log(log.decode('utf-8', errors='ignore'))
+
+                    if LABEL_CONTENT in stats:
+                        global_stats[LABEL_CONTENT_ERROR] += 1
+                    else:
+                        global_stats[stats[LABEL_TYPE]] += 1
+
+InfluxDbForwarder.close()
+end_time = time.time()
+
+global_stats['total_logs'] = totalLogs
+global_stats['time'] = end_time - start_time
+
+print(json.dumps(global_stats, indent=4))

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -80,7 +80,7 @@ def process_log(line: str) -> dict:
     return stats
 
 
-year = 2006
+year = XXXX
 totalLogs = 0
 input_path = os.environ.get('LOGS_OUTPUT_PATH')
 

--- a/src/logs/main.py
+++ b/src/logs/main.py
@@ -8,6 +8,7 @@ from src.logs.filter.access_resource_bitstream import AccessResourceBitstream
 
 from src.logs.transformer.to_json import ToJSON
 from src.logs.transformer.add_label import AddLabel
+from src.logs.transformer.add_timestamp import AddTimestamp
 from src.logs.transformer.remove_ipv6address import RemoveIPv6Address
 from src.logs.transformer.add_resource_id_label import AddResourceIdLabel
 from src.logs.transformer.add_default_ipaddress import AddDefaultIpAddress
@@ -45,6 +46,7 @@ def process_log(line: str) -> dict:
             LABEL_VALUE: line,
             LABEL_CONTENT: LABEL_CONTENT_ERROR
         }
+        AddTimestamp.transform(log, line)
         InfluxDbForwarder.forward(log, line)
 
         stats[LABEL_CONTENT] = LABEL_CONTENT_ERROR

--- a/src/logs/transformer/add_timestamp.py
+++ b/src/logs/transformer/add_timestamp.py
@@ -1,0 +1,11 @@
+from src.logs.transformer.transformer_interface import ITransformer
+
+import re
+
+
+class AddTimestamp(ITransformer):
+
+    @classmethod
+    def transform(cls, log: str, raw_log) -> None:
+        log['date'] = re.compile(r'\d{1,2}/\w{3}/\d{1,4}').findall(raw_log)[0]
+        log['time'] = re.compile(r':(.*)]').findall(raw_log)[0]

--- a/src/logs/transformer/add_timestamp.py
+++ b/src/logs/transformer/add_timestamp.py
@@ -3,7 +3,7 @@ from src.logs.transformer.transformer_interface import ITransformer
 import re
 
 
-class AddTimestamp(ITransformer):
+class AddTimestampForwarder(ITransformer):
 
     @classmethod
     def transform(cls, log: str, raw_log) -> None:

--- a/src/logs/utils/constants.py
+++ b/src/logs/utils/constants.py
@@ -4,6 +4,7 @@ LABEL_TYPE = "type"
 LABEL_TYPE_SEARCH = "cerca"
 LABEL_TYPE_OTHERS = "altres"
 LABEL_TYPE_RESOURCE = "recurs"
+LABEL_TYPE_RESOURCE_WEB = "recurs-web"
 
 LABEL_CONTENT = "content"
 LABEL_CONTENT_OK = "ok"


### PR DESCRIPTION
- `AddTimestampForwarder` used to get `time` and `date` of corrupted logs
- `mongo` version pinned to `4.4.6`, we do not have support for AVX and versions > 5 will fail
- add new label type -> `LABEL_TYPE_RESOURCE_WEB`
- `process_log` returns `stats`